### PR TITLE
Fix style conflict with row class

### DIFF
--- a/console.css
+++ b/console.css
@@ -6,7 +6,7 @@
   display: none;
 }
 
-.row {
+#debug .row {
   width: 100%;
   margin-bottom: 10px;
 }

--- a/console.js
+++ b/console.js
@@ -1,7 +1,7 @@
 
 ( function(factory) {
   "use strict";
-  const version = '1.1.0';
+  const version = '1.1.1';
   let w;
   if (typeof window !== typeof void 0) {
     w = window;


### PR DESCRIPTION
Scoped the class `row` in the styles to not conflict with other UI elements.